### PR TITLE
fix service creation log message with reducing severity

### DIFF
--- a/gphotospy/authorize.py
+++ b/gphotospy/authorize.py
@@ -58,7 +58,7 @@ def init(secrets):
     }
     try:
         service = build(service_name, version, credentials=credentials)
-        logging.info(service_name, 'service created successfully')
+        logging.debug('service created successfully: {}'.format(service_name))
         service_object["service"] = service
         return service_object
     except Exception as e:


### PR DESCRIPTION
I'm not sure what python versions you are pointed at, but for the most recents it prints an error:
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.0_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 1079, in emit
    msg = self.format(record)
  File "/usr/local/Cellar/python@3.9/3.9.0_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 923, in format
    return fmt.format(record)
  File "/usr/local/Cellar/python@3.9/3.9.0_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 659, in format
    record.message = record.getMessage()
  File "/usr/local/Cellar/python@3.9/3.9.0_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 363, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "./gsync.py", line 33, in <module>
    service = authorize.init(args.auth_file)
  File "/Users/oleg/Library/Python/3.9/lib/python/site-packages/gphotospy/authorize.py", line 61, in init
    logging.info(service_name, 'service created successfully')
Message: 'photoslibrary'
Arguments: ('service created successfully',)
```
It's not critical and is shown only if logging level is set to INFO or lower. This PR fixes error for both 2.7 and 3.x and reduces message severity to DEBUG in order to not mess output if calling program wants to print some useful info messages.