### PR TITLE
Handle empty mediaItems in search_album.

### DIFF
--- a/gphotospy/media.py
+++ b/gphotospy/media.py
@@ -955,6 +955,6 @@ class Media:
             result = self._service.mediaItems().search(
                 body=request_body).execute()
             page_token = result.get("nextPageToken", None)
-            curr_list = result.get("mediaItems")
+            curr_list = result.get("mediaItems", [])
             for media in curr_list:
                 yield media


### PR DESCRIPTION
When I apply the media `search_album` function on one of my google photo albums, I get
```  
  File "/home/asd/.local/lib/python3.8/site-packages/gphotospy/media.py", line 959, in search_album
    for media in curr_list:
TypeError: 'NoneType' object is not iterable
```
For some reason one of the media items responses is empty despite the fact that `nextPageToken` is not None and there is still at least one page left to be iterated.
This fixes the problem.