### PR TITLE
Allow uploads to stream in instead of requiring them on disk

### DIFF
--- a/gphotospy/media.py
+++ b/gphotospy/media.py
@@ -569,7 +569,7 @@ class Media:
             }
         }
 
-    def stage_media(self, media_file, description="", mime_type=None):
+    def stage_media(self, media_file, description="", mime_type=None, base_name=None):
         """
         Stage media to be added to the photo account,
         by uploading to Google server.
@@ -583,6 +583,10 @@ class Media:
             Path of the media file to be uploaded
         description: str, optional
             Description to display in the media info panel
+        mime_type: str, optional
+            Mime type to avoid looking up by file
+        base_name: str, optional
+            Can be passed to avoid looking up from upload path
 
         Returns
         -------
@@ -601,9 +605,11 @@ class Media:
         upload_token = upload(self._secrets, media_file, mime_type=mime_type)
         if upload_token is None:
             return None
+        if base_name is None:
+            base_name = os.path.basename(media_file)
         new_media = self.get_upload_object(
             upload_token,
-            os.path.basename(media_file),
+            base_name,
             description)
 
         self._staged_media.append(new_media)

--- a/gphotospy/media.py
+++ b/gphotospy/media.py
@@ -569,7 +569,7 @@ class Media:
             }
         }
 
-    def stage_media(self, media_file, description=""):
+    def stage_media(self, media_file, description="", mime_type=None):
         """
         Stage media to be added to the photo account,
         by uploading to Google server.
@@ -598,7 +598,7 @@ class Media:
 
         >>> media_manager.batchCreate()
         """
-        upload_token = upload(self._secrets, media_file)
+        upload_token = upload(self._secrets, media_file, mime_type=mime_type)
         if upload_token is None:
             return None
         new_media = self.get_upload_object(

--- a/gphotospy/upload.py
+++ b/gphotospy/upload.py
@@ -38,7 +38,7 @@ def upload(secrets, media_file, mime_type=None):
     header['X-Goog-Upload-Content-Type'] = mime_type
     is_file_like = False
     try: # maintain potential python2 compat
-        is_file_like = not isinstance(fp, str)
+        is_file_like = not isinstance(media_file, str)
     except:
         pass
     

--- a/gphotospy/upload.py
+++ b/gphotospy/upload.py
@@ -7,7 +7,7 @@ upload_url = 'https://photoslibrary.googleapis.com/v1/uploads'
 mimetypes.init()
 
 
-def upload(secrets, media_file):
+def upload(secrets, media_file, mime_type=None):
     """
     Uploads files of media to Google Server, to put in Photos
 
@@ -33,7 +33,9 @@ def upload(secrets, media_file):
         'X-Goog-Upload-Protocol': 'raw'
     }
 
-    header['X-Goog-Upload-Content-Type'] = mimetypes.guess_type(media_file)[0]
+    if mime_type is None:
+        mime_type =  mimetypes.guess_type(media_file)[0]
+    header['X-Goog-Upload-Content-Type'] = mime_type
     is_file_like = False
     try: # maintain potential python2 compat
         is_file_like = not isinstance(fp, str)

--- a/gphotospy/upload.py
+++ b/gphotospy/upload.py
@@ -16,8 +16,10 @@ def upload(secrets, media_file):
     secrets: str
         JSON file containing the secrets for OAuth,
         as created in the Google Cloud Consolle
-    media_file: Path
+    media_file: Path, file-like object, or requests iterator
         Path to the file to upload
+        File-like object opened in binary mode to upload
+        Python requests iterator for chunked encoded requests
 
     Returns
     -------
@@ -32,8 +34,15 @@ def upload(secrets, media_file):
     }
 
     header['X-Goog-Upload-Content-Type'] = mimetypes.guess_type(media_file)[0]
-
-    f = open(media_file, 'rb').read()
+    is_file_like = False
+    try: # maintain potential python2 compat
+        is_file_like = not isinstance(fp, str)
+    except:
+        pass
+    
+    f = media_file
+    if not is_file_like:
+        f = open(media_file, 'rb')
 
     response = requests.post(upload_url, data=f, headers=header)
     if response.ok:


### PR DESCRIPTION
I'm working on a script which copies photos from one account and dumps them into another. This saves from needing to write them all to disk and is more efficient overall.